### PR TITLE
Rearranging and adding a comment so every time debian apt indexes changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,17 @@ FROM jfromaniello/jekyll
 
 EXPOSE 80
 
+# install nodejs, npm and git
 RUN \
   apt-get update && \
-  apt-get install -y nginx && \
+  apt-get install -y nginx nodejs npm git git-core  # 2016-01-25
+
+# Set up nginx as no-daemon
+RUN \
   echo "\ndaemon off;" >> /etc/nginx/nginx.conf && \
   chown -R www-data:www-data /var/lib/nginx
 
 ADD nginx.conf /etc/nginx/nginx.conf
-
-# install nodejs and npm
-RUN apt-get install -y nodejs npm git git-core
 
 # install gems
 RUN gem install jekyll -v 2.4.0


### PR DESCRIPTION
...  we can invalidate docker cache by changing the comment (dirty hack to force an apt-get update since docker cache the results if the directive doesn't change)