### PR TITLE
Don't change the link rel canonical tag href attr

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -593,10 +593,6 @@
             $(window).scrollTop(0);
           }
 
-          // Update canonical url
-          $("link[rel='canonical']").attr("href", window.location.href);
-
-
           stickyElements();
         }
 


### PR DESCRIPTION
pajax was removed on https://github.com/auth0/blog/pull/285 so we no longer need to update the link rel canonical tag attr on pajax success (https://github.com/auth0/blog/pull/54).