### PR TITLE
feat(swiftype): Enable swiftype meta tags

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,6 +12,11 @@
       <title>{{ page.tag | capitalize }} - Auth0 Blog</title>
     {% else %}
       <title>{{ page.title }}</title>
+
+      <!-- Swiftype for the posts -->
+      <meta class="swiftype" name="title" data-type="string" content="{{ page.title }}"/>
+      <meta class="swiftype" name="type" data-type="enum" content="blog" />
+      <meta class="swiftype" name="popularity" data-type="integer" content="1"/>
     {% endif %}
 
     <link href="https://plus.google.com/+Auth0" rel="publisher" />


### PR DESCRIPTION
We are using swiftype to search for the articles, blog and forums, so it is necessary to put the tags in order to swiftype can scan the posts. 

More information: https://swiftype.com/documentation/meta_tags2