### PR TITLE
Fixes #636 - rss feed broken

### DIFF
--- a/rss.xml
+++ b/rss.xml
@@ -17,7 +17,7 @@ sitemap:
     {% for post in site.posts limit:10 %}
       {% unless post.draft %}
         <item>
-          <title>{{ post.title }}</title>
+          <title>{{ post.title | xml_escape }}</title>
           <link>https://auth0.com{{ site.baseurl }}{{ post.url }}</link>
           <pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
           <author>{{post.author.mail}}</author>


### PR DESCRIPTION
Ampersand on a post title was not getting properly encoded.