### PR TITLE
Add upgrade notice to Elm articles.

### DIFF
--- a/_posts/2016-08-04-creating-your-first-elm-app-part-1.markdown
+++ b/_posts/2016-08-04-creating-your-first-elm-app-part-1.markdown
@@ -24,7 +24,7 @@ related:
 
 <div class="alert alert-info alert-icon">
   <i class="icon-budicon-487"></i>
-  This article covers <strong>Elm v.0.17</strong>. To upgrade to Elm v.0.18, please see the <a href="https://github.com/elm-lang/elm-platform/blob/master/upgrade-docs/0.18.md">0.18 Upgrade Docs here</a>. In addition, make sure to address all applicable <a href="https://github.com/elm-lang/elm-platform/blob/master/upgrade-docs/0.18.md#package-changes">package changes</a>. 
+  This article covers <strong>Elm v0.17</strong>. To upgrade to Elm v0.18, please see the <a href="https://github.com/elm-lang/elm-platform/blob/master/upgrade-docs/0.18.md">0.18 Upgrade Docs here</a>. In addition, make sure to address all applicable <a href="https://github.com/elm-lang/elm-platform/blob/master/upgrade-docs/0.18.md#package-changes">package changes</a>. 
 </div>
 
 **TL;DR:** We can write statically typed, functional, reactive SPAs on the front end with [Elm](http://www.elm-lang.org). Elm's compiler prevents runtime errors and compiles to JavaScript, making it an excellent choice for clean, speedy development. In part one of this tutorial, learn how to write your first Elm app and request data from an API. In part two, we'll add authentication using JSON Web Tokens. The full code is available at [this GitHub repository](https://github.com/kmaida/auth0-elm-with-jwt-api).

--- a/_posts/2016-08-04-creating-your-first-elm-app-part-1.markdown
+++ b/_posts/2016-08-04-creating-your-first-elm-app-part-1.markdown
@@ -22,6 +22,11 @@ related:
 - 2016-07-14-create-an-app-in-vuejs-2
 ---
 
+<div class="alert alert-info alert-icon">
+  <i class="icon-budicon-487"></i>
+  This article covers <strong>Elm v.0.17</strong>. To upgrade to Elm v.0.18, please see the <a href="https://github.com/elm-lang/elm-platform/blob/master/upgrade-docs/0.18.md">0.18 Upgrade Docs here</a>. In addition, make sure to address all applicable <a href="https://github.com/elm-lang/elm-platform/blob/master/upgrade-docs/0.18.md#package-changes">package changes</a>. 
+</div>
+
 **TL;DR:** We can write statically typed, functional, reactive SPAs on the front end with [Elm](http://www.elm-lang.org). Elm's compiler prevents runtime errors and compiles to JavaScript, making it an excellent choice for clean, speedy development. In part one of this tutorial, learn how to write your first Elm app and request data from an API. In part two, we'll add authentication using JSON Web Tokens. The full code is available at [this GitHub repository](https://github.com/kmaida/auth0-elm-with-jwt-api).
 
 ---

--- a/_posts/2016-08-09-creating-your-first-elm-app-part-2.markdown
+++ b/_posts/2016-08-09-creating-your-first-elm-app-part-2.markdown
@@ -22,6 +22,11 @@ related:
 - 2016-07-14-create-an-app-in-vuejs-2
 ---
 
+<div class="alert alert-info alert-icon">
+  <i class="icon-budicon-487"></i>
+  This article covers <strong>Elm v.0.17</strong>. To upgrade to Elm v.0.18, please see the <a href="https://github.com/elm-lang/elm-platform/blob/master/upgrade-docs/0.18.md">0.18 Upgrade Docs here</a>. In addition, make sure to address all applicable <a href="https://github.com/elm-lang/elm-platform/blob/master/upgrade-docs/0.18.md#package-changes">package changes</a>. 
+</div>
+
 **TL;DR:** In the first part of this tutorial, we introduced the Elm language by building a [simple Elm Application that called an API](https://auth0.com/blog/creating-your-first-elm-app-part-1/). Now we'll authenticate with JSON Web Tokens to make protected API requests. The full code is available in [this GitHub repository](https://github.com/kmaida/auth0-elm-with-jwt-api).
 
 ---

--- a/_posts/2016-08-09-creating-your-first-elm-app-part-2.markdown
+++ b/_posts/2016-08-09-creating-your-first-elm-app-part-2.markdown
@@ -24,7 +24,7 @@ related:
 
 <div class="alert alert-info alert-icon">
   <i class="icon-budicon-487"></i>
-  This article covers <strong>Elm v.0.17</strong>. To upgrade to Elm v.0.18, please see the <a href="https://github.com/elm-lang/elm-platform/blob/master/upgrade-docs/0.18.md">0.18 Upgrade Docs here</a>. In addition, make sure to address all applicable <a href="https://github.com/elm-lang/elm-platform/blob/master/upgrade-docs/0.18.md#package-changes">package changes</a>. 
+  This article covers <strong>Elm v0.17</strong>. To upgrade to Elm v0.18, please see the <a href="https://github.com/elm-lang/elm-platform/blob/master/upgrade-docs/0.18.md">0.18 Upgrade Docs here</a>. In addition, make sure to address all applicable <a href="https://github.com/elm-lang/elm-platform/blob/master/upgrade-docs/0.18.md#package-changes">package changes</a>. 
 </div>
 
 **TL;DR:** In the first part of this tutorial, we introduced the Elm language by building a [simple Elm Application that called an API](https://auth0.com/blog/creating-your-first-elm-app-part-1/). Now we'll authenticate with JSON Web Tokens to make protected API requests. The full code is available in [this GitHub repository](https://github.com/kmaida/auth0-elm-with-jwt-api).


### PR DESCRIPTION
Elm v0.18 is out. Adding a notice about versioning for Elm articles that are using v0.17.