### PR TITLE
Add security note about APIs to Elm post.

### DIFF
--- a/_posts/2016-08-09-creating-your-first-elm-app-part-2.markdown
+++ b/_posts/2016-08-09-creating-your-first-elm-app-part-2.markdown
@@ -745,7 +745,9 @@ These modules are great resources to help you implement Auth0 with Elm. We will 
 
 ![elm with Auth0](https://cdn.auth0.com/blog/elm-auth/aside-auth0.jpg)
 
-You can download the complete code for the Elm app with Auth0 integration at [this GitHub repo](
+You can download the complete code for the Elm app with Auth0 integration at [this GitHub repo](https://github.com/auth0-blog/elm-with-auth0).
+
+> **Important security note:** In this demo, we're adding authentication to the client side but we are not securing a backend. If you have an API for your application, the API should _always_ be secured. The [`id_token` should not be used to secure an API](https://auth0.com/blog/why-should-use-accesstokens-to-secure-an-api); instead use an `access_token` with the appropriate configuration. You can read about how to [implement API authentication with Auth0](https://auth0.com/docs/apis) with [implicit grant](https://auth0.com/docs/api-auth/tutorials/implicit-grant).
 
 ### Sign Up for Auth0
 
@@ -1160,8 +1162,6 @@ We need to subscribe to the `auth0authResult` port to listen for external input 
 > **Note:** `>>` represents function chaining. 
 
 Finally, the view displays a message and button to open the lock widget if there is no authentication data in storage, and a greeting with the user's avatar along with a logout button if there is.
-
-> **Important security note:** In this simple demo, we're adding authentication to the client side but we are not securing a backend. If you have an API for your application, the API should _always_ be secured. You can read about how to [implement API authentication with Auth0](https://auth0.com/docs/apis) with [implicit grant](https://auth0.com/docs/api-auth/tutorials/implicit-grant).
 
 ## Elm: Now and Future
 

--- a/_posts/2016-08-09-creating-your-first-elm-app-part-2.markdown
+++ b/_posts/2016-08-09-creating-your-first-elm-app-part-2.markdown
@@ -1161,6 +1161,8 @@ We need to subscribe to the `auth0authResult` port to listen for external input 
 
 Finally, the view displays a message and button to open the lock widget if there is no authentication data in storage, and a greeting with the user's avatar along with a logout button if there is.
 
+> **Important security note:** In this simple demo, we're adding authentication to the client side but we are not securing a backend. If you have an API for your application, the API should _always_ be secured. You can read about how to [implement API authentication with Auth0](https://auth0.com/docs/apis) with [implicit grant](https://auth0.com/docs/api-auth/tutorials/implicit-grant).
+
 ## Elm: Now and Future
 
 We made a simple app but covered a lot of ground with Elm's architecture, syntax, and implementation of features you'll likely come across in web application development. Authenticating with JWT was straightforward and packages and JS interop offer a lot of extensibility.


### PR DESCRIPTION
The Elm post uses the Chuck Norris API and homegrown authentication in its demo. The Auth0 aside shows how to integrate Lock on the client-side only. An important security note has been added with links informing the reader how to set up APIs if needed and use implicit grant.