### PR TITLE
Implement Experimental Disclaimer Feature

### DIFF
--- a/_includes/experiment_disclaimer.html
+++ b/_includes/experiment_disclaimer.html
@@ -1,4 +1,4 @@
-{% if page.experimental %}
+{% if page.experimental == true %}
 <div class="alert alert-info">
   <strong>Attention</strong><br />
   <p style="color: #097093;">This post contains experimental code that has not undergone a thorough security review and should not be used in production without further vetting. Please use discretion when implementing in your code.</p> 

--- a/_includes/experiment_disclaimer.html
+++ b/_includes/experiment_disclaimer.html
@@ -1,0 +1,6 @@
+{% if page.experimental %}
+<div class="alert alert-info">
+  <strong>Attention</strong><br />
+  <p style="color: #097093;">This post contains experimental code that has not undergone a thorough security review and should not be used in production without further vetting. Please use discretion when implementing in your code.</p> 
+</div> 
+{% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -28,6 +28,7 @@ is_post: true
         <main class="blog-post blog-single">
           <div class="inner">
             <div class="entry-content js-entry-content" itemprop="articleBody">
+              {% include experiment_disclaimer.html %}
               {{ content }}
             </div>
             {% include reply_buttons.html %}

--- a/_posts/2017-05-17-two-factor-authentication-using-biometrics.markdown
+++ b/_posts/2017-05-17-two-factor-authentication-using-biometrics.markdown
@@ -18,6 +18,7 @@ tags:
 - Biometrics
 related:
 - 2016-11-30-different-ways-to-implement-multifactor
+experimental: true
 ---
 
 **TL;DR** You can replace the use of traditional multifactor possession factors (phone codes, special-purpose hardware) in 2FA implementations with the use of inherence factors (voice biometrics) by leveraging [Auth0](https://auth0.com/) extensibility points and voice recognition services (VoiceIt). Additionally, by integrating a communications platform (Twilio) you can let your users complete the voice authentication step through their own phones.


### PR DESCRIPTION
Adds a flag called "experimental" that when set to "true" will display a disclaimer at the top of article saying that the post contains experimental code and should not be used in production.