### PR TITLE
Auth0 Extend Blog: Extend Salesforce with Node.js - Updates

### DIFF
--- a/_posts/2017-08-15-extend-salesforce-with-node.markdown
+++ b/_posts/2017-08-15-extend-salesforce-with-node.markdown
@@ -25,6 +25,10 @@ related:
   - 2016-06-28-building-serverless-apps-with-webtask
 ---
 
+**tl;dr**: Extend for Salesforce lets you implement triggers in Node 8 with full access to 400k NPM modules. Check it out [auth0.com/extend/salesforce](https://auth0.com/extend/salesforce).
+
+---
+
 Salesforce is a powerful and mature SaaS CRM platform that developers can customize to meet their organization's business needs. For instance, you can author custom triggers which attach to the lifecycle of Salesforce objects. One catch, you need to learn Apex. If you are a NodeJS/Javascript developer, who has never worked with Apex, this can be a big jump. You need to move to a new language and ecosystem. That is until now.
 
 We want to enable NodeJS developers to harness the power of the Salesforce platform using the language and ecosystem they already know.

--- a/_posts/2017-08-15-extend-salesforce-with-node.markdown
+++ b/_posts/2017-08-15-extend-salesforce-with-node.markdown
@@ -24,7 +24,7 @@ related:
   - 2017-05-19-serverless-webhooks-with-auth0-extend
   - 2016-06-28-building-serverless-apps-with-webtask
 banner: 
-  action: https://auth0.com/extend/salesforce/app
+  action: https://auth0.com/extend/salesforce
   text: Extend for Salesforce with Node 8
   cta: Try It Out
 

--- a/_posts/2017-08-15-extend-salesforce-with-node.markdown
+++ b/_posts/2017-08-15-extend-salesforce-with-node.markdown
@@ -23,6 +23,11 @@ related:
   - 2017-05-16-introducing-auth0-extend-the-new-way-to-extend-your-saas
   - 2017-05-19-serverless-webhooks-with-auth0-extend
   - 2016-06-28-building-serverless-apps-with-webtask
+banner: 
+  action: https://auth0.com/extend/salesforce/app
+  text: Extend for Salesforce with Node 8
+  cta: Try It Out
+
 ---
 
 **tl;dr**: Extend for Salesforce lets you implement triggers in Node 8 with full access to 400k NPM modules. Check it out [auth0.com/extend/salesforce](https://auth0.com/extend/salesforce).


### PR DESCRIPTION
- [x] Add tl;dr section as a call to action
- [x] Update footer banner to be template-ized
- [x] Override footer banner content to point to auth0.com/extend/salesforce
- [ ] Get updated header image that looks more like [this](https://cdn.auth0.com/blog/office365-googleapps/logo.png)