### PR TITLE
Fix polymer package name, appears to be case sensitive

### DIFF
--- a/_posts/2016-10-05-build-your-first-app-with-polymer-and-web-components.markdown
+++ b/_posts/2016-10-05-build-your-first-app-with-polymer-and-web-components.markdown
@@ -83,7 +83,7 @@ npm install -g bower
 Install the Polymer CLI: 
 
 ```bash
-npm install -g polymer-CLI
+npm install -g polymer-cli
 ```
 
 We also need to have a sample Node API running. Clone the [NodeJS JWT Authentication sample repo](https://github.com/auth0-blog/nodejs-jwt-authentication-sample) and follow the instructions in the README to get it up and running on [http://localhost:3001](http://localhost:3001).


### PR DESCRIPTION
I noticed, while following this guide, that the polymer install failed with a 404 on `polymer-CLI` but worked perfectly with `polymer-cli`.

```bash
$ npm install -g polymer-CLI
npm ERR! code E404
... etc
$ npm install -g polymer-cli
npm WARN deprecated babel-preset-es2015@6.24.1: 🙌  Thanks for using Babel: we recommend using babel-preset-env now: please read babeljs.io/env to update! 
... etc
```

Appears to be lowercase on their guide: https://www.polymer-project.org/1.0/docs/tools/polymer-cli