### PR TITLE
Add Mac shortcut for em dash and fix grammar issues in Auth0 section …

### DIFF
--- a/post-cheat-sheet.markdown
+++ b/post-cheat-sheet.markdown
@@ -3,7 +3,7 @@ layout: post
 title: "Title Should be Less Than 56 characters"
 description: "Description goes here and must be less than 156 characters."
 longdescription: "Long description is used for meta tags, particularly for Google, and should be between 230-320 characters."
-date: 2017-10-05 8:30
+date: 2018-01-01 8:30
 category: Technical guide, Thing, Thing2, PR, Press
 (!CanRemoveIfFalse)press_release: true
 (!CanRemoveIfFalse)is_non-tech: true
@@ -107,10 +107,12 @@ text
 
 ### Characters
 
-* Em dash: `—` (don't use hyphens for this)
+* Em dash: `—` (don't use hyphens for this) - Mac shortcut: `Shift`+`Alt`+`-`
 * Lambda: `λ`
 
 ### Within-article Target Links
+
+HTML is required with a `target="_self"` because the blog programming will automatically open _all_ links in a new window unless this is specified. Markdown anchor links do not work.
 
 ```
 <a href="#some-target" target="_self">Link to Target</a>
@@ -124,11 +126,11 @@ text
 {% include tweet_quote.html quote_text="Lorem ipsum dolor sit amet." %}
 ```
 
-## Copy-Paste Auth0 Centralized Login Setup for SPAs
+## Copy-Paste Auth0 Login Setup for SPAs
 
 > **Important Note:** Make sure this is updated to reflect the appropriate application type, allowed callback settings, and API identifier when pasting into a post.
 
-![Auth0 centralized login screen](https://cdn.auth0.com/blog/resources/auth0-centralized-login.jpg)
+![Auth0 login screen](https://cdn.auth0.com/blog/resources/auth0-centralized-login.jpg)
 
 ### Sign Up for Auth0
 
@@ -138,12 +140,13 @@ You'll need an [Auth0](https://auth0.com) account to manage authentication. You 
 
 1. Go to your [**Auth0 Dashboard**](https://manage.auth0.com/#/) and click the "[create a new client](https://manage.auth0.com/#/clients/create)" button. 
 2. Name your new app, select "Single Page Web Applications", and click the "Create" button. 
-3. In the **Settings** for your new Auth0 client app, add `http://localhost:[PORT]/callback` to the **Allowed Callback URLs**.
+3. In the **Settings** for your new Auth0 client app, add `http://localhost:[PORT]` to the **Allowed Callback URLs**.
 4. Click the "Save Changes" button.
 5. If you'd like, you can [set up some social connections](https://manage.auth0.com/#/connections/social). You can then enable them for your app in the **Client** options under the **Connections** tab. The example shown in the screenshot above utilizes username/password database, Facebook, Google, and Twitter.
 
-> Note: On the **OAuth** tab of **Advanced Settings** (at the bottom of the **Settings** section) you can see the **JsonWebToken Signature Algorithm** is set to `RS256`. This is now the default, [read more about RS256 vs HS256 here](https://community.auth0.com/questions/6942/jwt-signing-algorithms-rs256-vs-hs256).
+> **Note:** Under the **OAuth** tab of **Advanced Settings** (at the bottom of the **Settings** section) you should see that the **JsonWebToken Signature Algorithm** is set to `RS256`. This is  the default for new clients. If it is set to `HS256`, please change it to `RS256`. You can [read more about RS256 vs. HS256 JWT signing algorithms here.](https://community.auth0.com/questions/6942/jwt-signing-algorithms-rs256-vs-hs256).
 
 ### Set Up an API
 
-Go to [**APIs**](https://manage.auth0.com/#/apis) in your dashboard and click on the "Create API" button. Enter a name for the API. Set the **Identifier** to your API endpoint URL. In this example, this is `http://localhost:[PORT]/api/`. The **Signing Algorithm** should be `RS256`.
+1. Go to [**APIs**](https://manage.auth0.com/#/apis) in your dashboard and click on the "Create API" button.
+2. Enter a name for the API. Set the **Identifier** to your API's URL. In this example, this is `http://localhost:[PORT]/api/`. The **Signing Algorithm** should be `RS256`.


### PR DESCRIPTION
…(also, remove references to "centralized" login, we should just be referring to this as "login page" and not centralized or universal login in technical tutorials.