### PR TITLE
Kanban board amendments

### DIFF
--- a/_posts/2018-03-29-vuejs-kanban-board-the-development-process.markdown
+++ b/_posts/2018-03-29-vuejs-kanban-board-the-development-process.markdown
@@ -817,7 +817,7 @@ Then, we will register the draggable component with our `TaskLane` component:
 // ..
 components: {
   item: TaskLaneItem,
-  draggables: Draggable,
+  draggable: Draggable,
 }
 // ..
 ```

--- a/_posts/2018-03-29-vuejs-kanban-board-the-development-process.markdown
+++ b/_posts/2018-03-29-vuejs-kanban-board-the-development-process.markdown
@@ -836,6 +836,16 @@ Now, we can wrap our task lane inside a Draggable component to enable the items 
 
 Here, the existing `<div v-for...>` element is wrapped in this new draggable component. We've set the model for this to be this thing called `draggables` and we've also set an option for the group to be the value `default`. These options are simply passed straight through to the underlying SortableJS instance (with the exception of some event handlers). Setting the group name is what allows items to be dragged from one list to another (from [the SortableJS documentation](https://github.com/RubaXa/Sortable#group-option)). Since we've got multiple task lanes all with their own `Draggable` component but with the same group name, we're able to drag task items between them! If we wanted to prevent tasks from being dragged into specific lanes, it follows that we would give them different group names to facilitate that feature.
 
+One last thing we need to do is fix a small styling issue. If you were to play around with the drag-drop feature now, you'll find that you won't be able to drag anything into any columns that are empty, because the empty columns have no height. We can fix that now by adding some styling to the bottom of the file that contains the `TaskLane` component, like so:
+
+{% highlight html %}
+<style>
+  .card-body > * {
+    min-height: 50px;
+  }
+</style>
+{% endhighlight %}
+
 If we load up the app now, we'll find that we'll be able to drag items from one lane to another - neat! However, notice that when you switch back to the Backlog view then return to the Kanban board, it hasn't remembered the positions of the tasks and you'll see them all sitting back in the To-Do lane, as they were originally. Let's fix that now by using a computed property to fetch the items.
 
 We've already used a computed property in a previous component, but this one is slightly different as we're going to tightly control what happens when you get and set that property. When the items are retrieved (get), we'll simply return the `items` prop that was given to the `TaskLane` component to render. When the items are put back (set), we'll commit those items back to the Vuex store.


### PR DESCRIPTION
This is based on reader comments that pointed out that there was no mention of the `min-height` style that is needed in order for the drag-drop facility to work properly. This code appears in the [companion application code](https://github.com/elkdanger/kanban-board/blob/master/src/components/TaskLane.vue#L50) but not in the article.

PR also includes a minor typo in the component registration, again a discrepancy from the companion code example.