### PR TITLE
Fix broken links and add related post links

### DIFF
--- a/_posts/2018-05-17-ruby-on-rails-killer-workflow-with-docker-part-1.md
+++ b/_posts/2018-05-17-ruby-on-rails-killer-workflow-with-docker-part-1.md
@@ -10,7 +10,7 @@ design:
   image: https://cdn.auth0.com/blog/ruby-workflow-docker/logo.png
 author:
   name: "Vijayabharathi Balasubramanian"
-  url: "https://twitter.com/vijayabharathib"
+  url: "https://www.pineboat.in/author/vijayabharathib/"
   mail: "yajiv.vijay@gmail.com"
   avatar: "https://cdn.auth0.com/blog/guest-authors/vijay.jpeg"
 tags:
@@ -25,6 +25,7 @@ tags:
 - continuous-delivery
 - auth0
 related:
+- 2018-05-24-ruby-on-rails-killer-workflow-with-docker-part-2
 - 2017-05-22-load-balancing-nodejs-applications-with-nginx-and-docker
 - 2017-01-03-rails-5-with-auth0
 ---

--- a/_posts/2018-05-24-ruby-on-rails-killer-workflow-with-docker-part-2.md
+++ b/_posts/2018-05-24-ruby-on-rails-killer-workflow-with-docker-part-2.md
@@ -10,7 +10,7 @@ design:
   image: https://cdn.auth0.com/blog/ruby-workflow-docker/logo.png
 author:
   name: "Vijayabharathi Balasubramanian"
-  url: "vijayabharathib"
+  url: "https://www.pineboat.in/author/vijayabharathib/"
   mail: "yajiv.vijay@gmail.com"
   avatar: "https://cdn.auth0.com/blog/guest-authors/vijay.jpeg"
 tags:


### PR DESCRIPTION
Par 2: pointed author link to personal profile page. This fixes 404 error
Part 1: pointed author link to personal profile page to be consistent.
Part 1: added a link to part 2 under related posts section (same way it was done on part 2).