### PR TITLE
Removing the alias check

### DIFF
--- a/_includes/social_buttons.html
+++ b/_includes/social_buttons.html
@@ -4,11 +4,7 @@
   {% assign current = page %}
 {% endif %}
 
-{% if current.alias %}
-  {% assign url = current.alias %}
-{% else %}
-  {% assign url = current.url %}
-{% endif %}
+{% assign url = current.url %}
 
 <div class="social-stats">
   <a href="#" data-url="https://auth0.com/blog{{url}}" data-type="twitter" data-txt="{{current.title}}" data-via="auth0" class="network">


### PR DESCRIPTION
This is done to resolve legacy/old posts shared to social.

See: https://github.com/auth0/blog/issues/1599