### PR TITLE
SEO lang attribute - optimizations throughout 

### DIFF
--- a/_includes/locales.html
+++ b/_includes/locales.html
@@ -1,12 +1,12 @@
 {% if page.alternate_locale_en %}
-<link rel="alternate" href="https://auth0.com{{ site.baseurl }}/{{page.alternate_locale_en}}" hreflang="en" />
+<link rel="alternate" href="https://auth0.com{{ site.baseurl }}/{{page.alternate_locale_en}}/" hreflang="en" />
 {% endif %}
 {% if page.alternate_locale_es %}
-<link rel="alternate" href="https://auth0.com{{ site.baseurl }}/{{page.alternate_locale_es}}" hreflang="es" />
+<link rel="alternate" href="https://auth0.com{{ site.baseurl }}/{{page.alternate_locale_es}}/" hreflang="es" />
 {% endif %}
 {% if page.alternate_locale_de %}
-<link rel="alternate" href="https://auth0.com{{ site.baseurl }}/{{page.alternate_locale_de}}" hreflang="de" />
+<link rel="alternate" href="https://auth0.com{{ site.baseurl }}/{{page.alternate_locale_de}}/" hreflang="de" />
 {% endif %}
 {% if page.alternate_locale_ja %}
-<link rel="alternate" href="https://auth0.com{{ site.baseurl }}/{{page.alternate_locale_ja}}" hreflang="ja" />
+<link rel="alternate" href="https://auth0.com{{ site.baseurl }}/{{page.alternate_locale_ja}}/" hreflang="ja" />
 {% endif %}

--- a/_includes/locales.html
+++ b/_includes/locales.html
@@ -1,12 +1,16 @@
 {% if page.alternate_locale_en %}
 <link rel="alternate" href="https://auth0.com{{ site.baseurl }}/{{page.alternate_locale_en}}/" hreflang="en" />
+<link rel="alternate" href="https://auth0.com{{ site.baseurl }}{{page.url}}" hreflang="{{ page.lang }}" />
 {% endif %}
 {% if page.alternate_locale_es %}
 <link rel="alternate" href="https://auth0.com{{ site.baseurl }}/{{page.alternate_locale_es}}/" hreflang="es" />
+<link rel="alternate" href="https://auth0.com{{ site.baseurl }}{{page.url}}" hreflang="{{ page.lang }}" />
 {% endif %}
 {% if page.alternate_locale_de %}
 <link rel="alternate" href="https://auth0.com{{ site.baseurl }}/{{page.alternate_locale_de}}/" hreflang="de" />
+<link rel="alternate" href="https://auth0.com{{ site.baseurl }}{{page.url}}" hreflang="{{ page.lang }}" />
 {% endif %}
 {% if page.alternate_locale_ja %}
 <link rel="alternate" href="https://auth0.com{{ site.baseurl }}/{{page.alternate_locale_ja}}/" hreflang="ja" />
+<link rel="alternate" href="https://auth0.com{{ site.baseurl }}{{page.url}}" hreflang="{{ page.lang }}" />
 {% endif %}

--- a/_layouts/amp.html
+++ b/_layouts/amp.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡ lang="en">
+<html ⚡ lang="{% if page.lang == null %}en{% elsif page.lang %}{{page.lang}}{% endif %}">
 <head>
 
 <link href="https://fonts.googleapis.com/css?family=Inconsolata|Montserrat" rel="stylesheet">

--- a/_layouts/amp.html
+++ b/_layouts/amp.html
@@ -20,7 +20,7 @@
 {%else %}
 <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url | replace: '/amp',''}}">
 {%endif%}
-<link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">
+<link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/rss.xml" | prepend: site.baseurl | prepend: site.url }}">
 
 
     {% if page.meta-robots %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="header-dark">
+<html class="header-dark" lang="{% if page.lang == null %}en{% elsif page.lang %}{{page.lang}}{% endif %}">
 
   {% include head.html %}
 

--- a/_posts/2015-10-07-jp-refresh-tokens-what-are-they-and-when-to-use-them.markdown
+++ b/_posts/2015-10-07-jp-refresh-tokens-what-are-they-and-when-to-use-them.markdown
@@ -25,7 +25,7 @@ tags:
 related:
 - jp-reactjs-authentication
 - jp-vuejs2-authentication
-lang: jp
+lang: ja
 alternate_locale_en: refresh-tokens-what-are-they-and-when-to-use-them
 
 ---

--- a/_posts/2016-09-29-jp-angular-2-authentication.markdown
+++ b/_posts/2016-09-29-jp-angular-2-authentication.markdown
@@ -21,7 +21,7 @@ tags:
 related:
 - jp-reactjs-authentication
 - jp-vuejs2-authentication
-lang: jp
+lang: ja
 alternate_locale_en: angular-2-authentication
 ---
 

--- a/_posts/2016-10-17-jp-sso-login-key-benefits-and-implementation.markdown
+++ b/_posts/2016-10-17-jp-sso-login-key-benefits-and-implementation.markdown
@@ -25,7 +25,7 @@ related:
 - jp-reactjs-authentication
 - jp-vuejs2-authentication
 - jp-securing-asp-dot-net-core-2-applications-with-jwts
-lang: jp
+lang: ja
 alternate_locale_en: sso-login-key-benefits-and-implementation
 ---
 

--- a/_posts/2016-11-21-jp-building-and-authenticating-nodejs-apps.markdown
+++ b/_posts/2016-11-21-jp-building-and-authenticating-nodejs-apps.markdown
@@ -22,7 +22,7 @@ tags:
 related:
 - jp-reactjs-authentication
 - jp-vuejs2-authentication
-lang: jp
+lang: ja
 alternate_locale_en: building-and-authenticating-nodejs-apps
 ---
 

--- a/_posts/2016-12-05-jp-how-saml-authentication-works.markdown
+++ b/_posts/2016-12-05-jp-how-saml-authentication-works.markdown
@@ -19,7 +19,7 @@ tags:
 related:
 - jp-reactjs-authentication
 - jp-vuejs2-authentication
-lang: jp
+lang: ja
 alternate_locale_en: how-saml-authentication-works
 ---
 

--- a/_posts/2017-02-21-jp-reactjs-authentication-tutorial.markdown
+++ b/_posts/2017-02-21-jp-reactjs-authentication-tutorial.markdown
@@ -22,7 +22,7 @@ tags:
 related:
 - jp-vuejs2-authentication
 - jp-angular-2-authentication
-lang: jp
+lang: ja
 alternate_locale_en: reactjs-authentication-tutorial
 ---
 

--- a/_posts/2017-04-18-jp-vuejs2-authentication-tutorial.markdown
+++ b/_posts/2017-04-18-jp-vuejs2-authentication-tutorial.markdown
@@ -21,7 +21,7 @@ tags:
 related:
 - jp-angular-2-authentication
 - jp-reactjs-authentication
-lang: jp
+lang: ja
 alternate_locale_en: vuejs2-authentication-tutorial
 ---
 

--- a/_posts/2017-12-07-jp-securing-asp-dot-net-core-2-applications-with-jwts.markdown
+++ b/_posts/2017-12-07-jp-securing-asp-dot-net-core-2-applications-with-jwts.markdown
@@ -22,7 +22,7 @@ tags:
 related:
 - jp-reactjs-authentication
 - jp-vuejs2-authentication
-lang: jp
+lang: ja
 alternate_locale_en: securing-asp-dot-net-core-2-applications-with-jwts
 ---
 


### PR DESCRIPTION
No pages, posts, or AMP posts are currently marked-up with `lang="iso-code"`, working to resolve and correct this for our English, Japanese, and other versions.

More to come.