### PR TITLE
Updating alias format

### DIFF
--- a/_posts/2012-01-27-hello-world.markdown
+++ b/_posts/2012-01-27-hello-world.markdown
@@ -2,7 +2,7 @@
 layout: post
 title: "hello world!"
 date: 2012-01-27 15:14
-alias: /2012/01/27/hello-world/
+alias: [/2012/01/27/hello-world]
 author:
   name: Matias Woloski
   mail: matias@auth0.com


### PR DESCRIPTION
A discovery from QAing current alias setup, the shot below shows that the redirects in-place with for old posts (when dates removed from url) don’t go to full canonical/optimized url - adds an extra trailing slash at the end of url.

<img width="967" alt="screen shot 2018-08-09 at 11 24 34 am" src="https://user-images.githubusercontent.com/40675103/43915711-ca5e905c-9bc8-11e8-8f08-2ec86c3281d8.png">

Testing new aliases format here to ensure won’t add extra “/”