### PR TITLE
Amp layout work

### DIFF
--- a/_includes/amp/amp_sidebar.html
+++ b/_includes/amp/amp_sidebar.html
@@ -20,55 +20,47 @@
     <ul>
       <li>
         <a href="https://auth0.com/how-it-works" data-amp-replace="CLIENT_ID" data-amp-addparams="anonId=CLIENT_ID(cid-scope-cookie-fallback-name)">
-
             Platform
         </a>
       </li>
       <li>
         <a href="https://auth0.com/enterprise" data-amp-replace="CLIENT_ID" data-amp-addparams="anonId=CLIENT_ID(cid-scope-cookie-fallback-name)">
-
             Enterprise
         </a>
       <li>
         <a href="https://auth0.com/lock" data-amp-replace="CLIENT_ID" data-amp-addparams="anonId=CLIENT_ID(cid-scope-cookie-fallback-name)">
-
             Lock
         </a>
       </li>
       <li>
         <a href="https://auth0.com/passwordless" data-amp-replace="CLIENT_ID" data-amp-addparams="anonId=CLIENT_ID(cid-scope-cookie-fallback-name)">
-
             Passwordless
         </a>
       </li>
       <li>
         <a href="https://auth0.com/breached-passwords" data-amp-replace="CLIENT_ID" data-amp-addparams="anonId=CLIENT_ID(cid-scope-cookie-fallback-name)">
-
           Breached Passwords
         </a>
       </li>
       <li>
         <a href="https://auth0.com/wordpress" data-amp-replace="CLIENT_ID" data-amp-addparams="anonId=CLIENT_ID(cid-scope-cookie-fallback-name)">
-
           Wordpress
         </a>
       </li>
       <li>
         <a href="https://auth0.com/multifactor-authentication" data-amp-replace="CLIENT_ID" data-amp-addparams="anonId=CLIENT_ID(cid-scope-cookie-fallback-name)">
-
           Multifactor Authentication
         </a>
       </li>
       <li>
         <a href="https://webtask.io/">
-
             Webtask
         </a>
       </li>
     </ul>
   </div>
-  <a class="sidebar-footer" id='amp-signup' href="https://auth0.com/signup"
-    data-amp-replace="CLIENT_ID" data-amp-addparams="anonId=CLIENT_ID(cid-scope-cookie-fallback-name)">
-    <span>SING UP</span>
-  </a>
+  <div class="sidebar-footer">
+    <a id='amp-signup' href="https://auth0.com/signup"
+      data-amp-replace="CLIENT_ID" data-amp-addparams="anonId=CLIENT_ID(cid-scope-cookie-fallback-name)">Sign Up</a>    
+  </div>
 </amp-sidebar>

--- a/_sass/amp/sidebar.scss
+++ b/_sass/amp/sidebar.scss
@@ -59,14 +59,16 @@ amp-sidebar {
   .sidebar-footer{
     min-height: 9.8%;
     background: rgb(235,84,36);
-    color: #fff;
     width: 100%;
     margin: 0px;
-    font-size: 20px;
-    letter-spacing: 0.85px;
     display: flex;
     justify-content: center;
     align-items: center;
+    a {
+      color: #fff;
+      font-size: 20px;
+      letter-spacing: 0.85px;
+    }
   }
 }
 

--- a/_sass/amp/sidebar.scss
+++ b/_sass/amp/sidebar.scss
@@ -16,15 +16,14 @@ amp-sidebar {
   width: 100%;
   background-color: #fff;
   .header{
-    min-height: 11.7%;
+    min-height: 10%;
     display: flex;
     justify-content: flex-end;
     align-items: center;
     padding-right: 33px;
-    border-bottom: 1px solid rgb(151,151,151);
     .amp-close-image{
       width: 23px;
-      height: 21px;
+      height: 23px;
     }
   }
 
@@ -40,7 +39,7 @@ amp-sidebar {
       font-size: 28.5px;
       letter-spacing: 1.2px;
       padding-bottom: 12px;
-      margin: 39px 10px 30px 47px;
+      margin: 0px 10px 30px 47px;
     }
     ul{
       list-style: none;
@@ -60,7 +59,7 @@ amp-sidebar {
     min-height: 9.8%;
     background: rgb(235,84,36);
     width: 100%;
-    margin: 0px;
+    margin: -41px 0px 0px 0px;
     display: flex;
     justify-content: center;
     align-items: center;


### PR DESCRIPTION
AMP layout and navigation design issues.

amp-sidebar (main navigation for AMP layout pages) doesn't display the Sign Up CTA button correctly on mobile displays

you have to account for that box that Google displayer for AMP pages shows on`https://www.google.com/amp/s/` url `https://www.google.com/amp/s/auth0.com/blog/amp/`

<img width="1288" alt="screen shot 2018-08-21 at 4 32 04 pm" src="https://user-images.githubusercontent.com/40675103/44432644-21f5cb00-a560-11e8-9662-88a1c32c0ab8.png">
