### PR TITLE
Add post_length to Rakefile and post length bash script

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -51,6 +51,7 @@ description: <Shorter shown underneath the title on the post itself and on blog 
 metadescription: <Richer, longer description that shows in search engines - must be less than 160 characters>
 date: #{Time.now.strftime('%Y-%m-%d %H:%M')}
 category: <FROM HERE: https://auth0team.atlassian.net/wiki/spaces/CON/pages/137692473/Blog+Post+Categories>
+post_length: <1-5 (Run postlength.sh to generate score when article is ready)>
 auth0_aside: <true|false (FOR FALSE YOU COULD ALSO REMOVE THIS LINE)>
 press_release: <true|false (FOR FALSE YOU COULD ALSO REMOVE THIS LINE)>
 is_non-tech: <true|false (FOR FALSE YOU COULD ALSO REMOVE THIS LINE)>

--- a/post-cheat-sheet.markdown
+++ b/post-cheat-sheet.markdown
@@ -6,6 +6,7 @@ description: "Shorter shown underneath the title on the post itself and on blog 
 metadescription: "Richer, longer description that shows in search engines - must be less than 160 characters."
 date: 2018-mm-dd 8:30
 category: Technical guide, Thing, Thing2, PR, Press
+post_length: 1-5 (Run postlength.sh to generate score when article is ready)
 (!CanRemoveIfFalse)press_release: true
 (!CanRemoveIfFalse)is_non-tech: true
 (!If post has technical Auth0 Aside)auth0_aside: true
@@ -21,7 +22,7 @@ design:
   bg_color: "#"
 tags:
 - hyphenated-tags
-- 
+-
 related:
 - date-postname
 - date-postname
@@ -57,7 +58,7 @@ Center an image:
 
 ```html
 <a href="http://url.goes.here">Link text</a>
-``` 
+```
 
 ### Blockquote (Quote)
 
@@ -173,8 +174,8 @@ You'll need an [Auth0](https://auth0.com) account to manage authentication. You 
 
 ### Set Up an Application
 
-1. Go to your [**Auth0 Dashboard**](https://manage.auth0.com/#/) and click the "[create a new application](https://manage.auth0.com/#/applications/create)" button. 
-2. Name your new app, select "Single Page Web Applications," and click the "Create" button. 
+1. Go to your [**Auth0 Dashboard**](https://manage.auth0.com/#/) and click the "[create a new application](https://manage.auth0.com/#/applications/create)" button.
+2. Name your new app, select "Single Page Web Applications," and click the "Create" button.
 3. In the **Settings** for your new Auth0 app, add `http://localhost:[PORT]/callback` to the **Allowed Callback URLs**.
 4. Add `http://localhost:[PORT]` to the **Allowed Logout URLs**.
 5. Click the "Save Changes" button.

--- a/postlength.sh
+++ b/postlength.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Outputs your post's word count and post length score
+# Run the script and pass in the path to your post:
+# source ./postlength.sh 2018-08-27-my-post.markdown
+# Then add the score to your article front matter as post_length.
+WORDS=$(wc -w < "$1")
+echo "word count:" $WORDS
+if [ "$WORDS" -le 1500 ]; then
+  POST_LENGTH=1
+elif [ "$WORDS" -gt 1501 ] && [ "$WORDS" -le 2500 ]; then
+  POST_LENGTH=2
+elif [ "$WORDS" -gt 2501 ] && [ "$WORDS" -le 4000 ]; then
+  POST_LENGTH=3
+elif [ "$WORDS" -gt 4001 ] && [ "$WORDS" -le 6000 ]; then
+  POST_LENGTH=4
+elif [ "$WORDS" -gt 6000 ]; then
+  POST_LENGTH=5
+fi
+echo "post length score:" $POST_LENGTH


### PR DESCRIPTION
This commit adds the `post_length` attribute to the Rakefile and adds a bash script called `postlength.sh` to the root of the repo. This script generates a score based on the word count of the file passed into the script. Authors can run this script and add that score to post front matter as `post_length`.