### PR TITLE
Re-prioritizing title over metatitle for social sharing

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -46,7 +46,7 @@ task :new_post, :title do |t, args|
 ---
 layout: post
 title: #{title.gsub(/&/,'&amp;')}
-metatitle: <Title displayed in search engines and social - less than 60 characters>
+metatitle: <Title displayed in search engines - less than 60 characters>
 description: <Shorter shown underneath the title on the post itself and on blog feed - must be less than 110 characters>
 metadescription: <Richer, longer description that shows in search engines - must be less than 160 characters>
 date: #{Time.now.strftime('%Y-%m-%d %H:%M')}

--- a/_includes/sharing_metas.html
+++ b/_includes/sharing_metas.html
@@ -2,10 +2,10 @@
 <meta property="fb:app_id" content="534074790006350"/>
 {% if page.is_tag_index or page.switch_index %}
   <meta property="og:title" content="{{ page.tag | capitalize }} - Auth0 Blog" />
-{% elsif page.metatitle %}
-  <meta property="og:title" content="{{ page.metatitle }}">
+{% elsif page.title %}
+  <meta property="og:title" content="{{ page.title }}">
 {% else %}
-  <meta property="og:title" content="{{ page.title }}" />
+  <meta property="og:title" content="{{ page.metatitle }}" />
 {% endif %}
 <meta property="og:site_name" content="Auth0 - Blog" />
 <meta property="og:url" content="https://auth0.com{{ site.baseurl }}{{ page.url | replace:'index.html'}}" />
@@ -36,10 +36,10 @@
 <!-- Twitter Cards -->
 <meta name="twitter:site" content="@auth0">
 <meta name="twitter:creator" content="@auth0">
-{% if page.metatitle %}
-  <meta name="twitter:title" content="{{ page.metatitle }}">
-{% elsif page.title %}
+{% if page.title %}
   <meta name="twitter:title" content="{{ page.title }}">
+{% elsif page.metatitle %}
+  <meta name="twitter:title" content="{{ page.metatitle }}">
 {% else %}
   {% if page.is_tag_index or page.switch_index %}
     <meta name="twitter:title" content="{{ page.tag | capitalize }} - Auth0 Blog">

--- a/_includes/social_buttons.html
+++ b/_includes/social_buttons.html
@@ -7,7 +7,7 @@
 {% assign url = current.url %}
 
 <div class="social-stats">
-  <a href="#" data-url="https://auth0.com/blog{{url}}" data-type="twitter" data-txt="{% if page.metatitle %}{{ page.metatitle }}{% elsif page.title %}{{ page.title }}{% endif %}" data-via="auth0" class="network">
+  <a href="#" data-url="https://auth0.com/blog{{url}}" data-type="twitter" data-txt="{% if page.title %}{{ page.title }}{% elsif page.metatitle %}{{ page.metatitle }}{% endif %}" data-via="auth0" class="network">
 
     <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="22" height="22" viewBox="0 0 512 512" enable-background="new 0 0 512 512" xml:space="preserve">
 
@@ -27,7 +27,7 @@
 
   </a>
 
-  <a href="#" data-url="https://auth0.com/blog{{url}}" data-type="linkedin" data-txt="{% if page.metatitle %}{{ page.metatitle }}{% elsif page.title %}{{ page.title }}{% endif %}" class="network">
+  <a href="#" data-url="https://auth0.com/blog{{url}}" data-type="linkedin" data-txt="{% if page.title %}{{ page.title }}{% elsif page.metatitle %}{{ page.metatitle }}{% endif %}" class="network">
     <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="22" height="22" viewBox="0 0 512 512" enable-background="new 0 0 512 512" xml:space="preserve">
 
     <path id="linkedin-icon" d="M411.945,50h-312c-27.614,0-50,22.386-50,50v312c0,27.614,22.386,50,50,50h312
@@ -45,7 +45,7 @@
     </svg>
   </a>
 
-  <a href="#" data-url="https://auth0.com/blog{{url}}" data-type="facebook" data-txt="{% if page.metatitle %}{{ page.metatitle }}{% elsif page.title %}{{ page.title }}{% endif %}" class="network">
+  <a href="#" data-url="https://auth0.com/blog{{url}}" data-type="facebook" data-txt="{% if page.title %}{{ page.title }}{% elsif page.metatitle %}{{ page.metatitle }}{% endif %}" class="network">
     <svg width="17" height="17" viewBox="0 0 412 412" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
       <g id="facebook-icon" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
           <path d="M283.80119,412 L361.995375,412 C389.611494,412 412,389.612167 412,361.995375 L412,50.0046252 C412,22.3885058 389.612167,0 361.995375,0 L50.0046252,0 C22.3885058,0 0,22.3878333 0,50.0046252 L0,361.995375 C0,389.611494 22.3878333,412 50.0046252,412 L219.907783,412 L219.907783,254.137637 L166.482996,254.137637 L166.482996,192.266054 L219.907783,192.266054 L219.907783,146.637452 C219.907783,93.6867027 252.247398,64.8530656 299.484232,64.8530656 C322.110827,64.8530656 341.559134,66.5376524 347.225329,67.2916602 L347.225329,122.6301 L314.462578,122.644417 C288.775412,122.644417 283.80119,134.851707 283.80119,152.764958 L283.80119,192.266054 L345.068293,192.266054 L337.089173,254.137637 L283.80119,254.137637 L283.80119,412 Z" id="Rectangle-1" fill="#000000" sketch:type="MSShapeGroup"></path>

--- a/post-cheat-sheet.markdown
+++ b/post-cheat-sheet.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Title displayed on the post itself, blog search, and on blog feed."
-metatitle: "Title displayed in search engines and social - less than 60 characters"
+metatitle: "Title displayed in search engines - less than 60 characters"
 description: "Shorter shown underneath the title on the post itself and on blog feed - must be less than 110 characters."
 metadescription: "Richer, longer description that shows in search engines - must be less than 160 characters."
 date: 2018-mm-dd 8:30


### PR DESCRIPTION
Keeping post field `metatitle` solely for the value it brings to SERPs, yet changing `_includes` to not source this as what’s pulled into sharing on social as per conversation with @RamiroND.

That will remain/revert to pulling the `<h1>` (`title` field). Think this will be best in the long run and lessens opportunities for disconnect between titles.